### PR TITLE
look up if lang to highlight exists

### DIFF
--- a/ghmd.js
+++ b/ghmd.js
@@ -15,7 +15,9 @@ module.exports = async function ghmd (title, markdown, opts) {
     breaks: true,
     langPrefix: 'hljs ',
     highlight: (string, lang) => {
-      if (lang) return hljs.highlight(lang, string).value
+      if (lang && hljs.getLanguage(lang)) {
+        return hljs.highlight(lang, string).value
+      }
       return hljs.highlightAuto(string).value
     }
   }, opts.markdownIt || {}))


### PR DESCRIPTION
i have a couple of .md files with language syntaxes not supported by `highlightjs` which results in error. this change allows file to be processed when `lang` can't be found by `highlightjs`